### PR TITLE
Add minimal Chrome extension

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -1,0 +1,6 @@
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request === 'GET_SELECTION') {
+    const text = window.getSelection().toString() || document.title;
+    sendResponse({ text });
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Copy Selection",
+  "description": "Copy selected text from the current page.",
+  "version": "1.0",
+  "manifest_version": 3,
+  "permissions": ["activeTab"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Copy Selection"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content_script.js"]
+    }
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Copy Selection</title>
+  <style>
+    body {
+      min-width: 200px;
+      min-height: 100px;
+      font-family: Arial, sans-serif;
+      padding: 10px;
+    }
+    button {
+      padding: 5px 10px;
+      font-size: 14px;
+    }
+    #status {
+      margin-left: 10px;
+    }
+  </style>
+</head>
+<body>
+  <button id="copy">Copy Selection</button>
+  <span id="status"></span>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const copyBtn = document.getElementById('copy');
+  const status = document.getElementById('status');
+
+  copyBtn.addEventListener('click', async () => {
+    status.textContent = '';
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    chrome.tabs.sendMessage(tab.id, 'GET_SELECTION', response => {
+      if (chrome.runtime.lastError || !response) {
+        status.textContent = 'Failed to get selection';
+        return;
+      }
+      navigator.clipboard.writeText(response.text).then(() => {
+        status.textContent = 'Copied!';
+      }).catch(() => {
+        status.textContent = 'Copy failed';
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Chrome extension folder with manifest v3 setup
- implement content script to read selected text
- create popup with copy button and clipboard handling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68582e4b31a0832c9b30d3ee3d9f378f