### PR TITLE
Add Copy button for Google Flights rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # copy-my-flight
-✈️ A Chrome extension to copy formatted flight details from Google Flights with one click.
+
+A Chrome extension that lets you copy selected text or flight details from Google Flights with one click.
+
+## Features
+
+- Adds a **Copy** button to each result row on Google Flights.
+- Copies the flight in the format `02:00 TPE > 10:00 CTS, Scoot, TWD1120`.
+- Shows a short confirmation after copying.
+- Popup button still copies the current selection on any page.
+
+To install, load the `extension/` directory as an unpacked extension in Chrome.

--- a/extension/flight_copy.js
+++ b/extension/flight_copy.js
@@ -1,0 +1,78 @@
+(function(){
+  // Only run on Google Flights pages
+  if(!location.href.includes('google.com/travel/flights')) return;
+
+  function showMessage(text){
+    const div = document.createElement('div');
+    div.textContent = text;
+    Object.assign(div.style, {
+      position: 'fixed',
+      bottom: '10px',
+      right: '10px',
+      background: 'rgba(0,0,0,0.8)',
+      color: '#fff',
+      padding: '6px 8px',
+      borderRadius: '4px',
+      zIndex: 9999,
+      fontSize: '12px'
+    });
+    document.body.appendChild(div);
+    setTimeout(() => div.remove(), 2000);
+  }
+
+  function formatRow(row){
+    const text = row.innerText;
+    if(!text) return null;
+
+    const timeRegex = /(\d{1,2}:\d{2})/g;
+    const airportRegex = /\b[A-Z]{3}\b/g;
+    const times = text.match(timeRegex) || [];
+    const airports = text.match(airportRegex) || [];
+
+    const airlineEl = row.querySelector('[data-testid="airline-name"], [class*="airline"]');
+    const priceEl = row.querySelector('[data-testid="listing-price-dollars"], [data-testid="offer-price"]');
+
+    const depTime = times[0] || '';
+    const arrTime = times[1] || '';
+    const depAirport = airports[0] || '';
+    const arrAirport = airports[1] || '';
+    const airline = airlineEl ? airlineEl.innerText.trim() : '';
+    const price = priceEl ? priceEl.innerText.trim() : '';
+
+    if(!(depTime && arrTime && depAirport && arrAirport && airline && price)) return null;
+    return `${depTime} ${depAirport} > ${arrTime} ${arrAirport}, ${airline}, ${price}`;
+  }
+
+  function addButtons(){
+    const rows = document.querySelectorAll('[role="listitem"]');
+    rows.forEach(row => {
+      if(row.querySelector('.copy-flight-btn')) return;
+      const btn = document.createElement('button');
+      btn.textContent = 'Copy';
+      btn.className = 'copy-flight-btn';
+      Object.assign(btn.style, {
+        marginLeft: '8px',
+        padding: '2px 6px',
+        fontSize: '12px'
+      });
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const formatted = formatRow(row);
+        if(!formatted){
+          showMessage('Failed to parse');
+          return;
+        }
+        navigator.clipboard.writeText(formatted).then(() => {
+          showMessage('Copied!');
+        }, () => {
+          showMessage('Copy failed');
+        });
+      });
+      row.appendChild(btn);
+    });
+  }
+
+  const observer = new MutationObserver(() => addButtons());
+  observer.observe(document.body, {childList: true, subtree: true});
+  addButtons();
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,9 +1,10 @@
 {
-  "name": "Copy Selection",
-  "description": "Copy selected text from the current page.",
-  "version": "1.0",
+  "name": "Copy My Flight",
+  "description": "Copy formatted flight details from Google Flights or selected text.",
+  "version": "1.1",
   "manifest_version": 3,
-  "permissions": ["activeTab"],
+  "permissions": ["activeTab", "clipboardWrite"],
+  "host_permissions": ["https://www.google.com/travel/flights/*"],
   "action": {
     "default_popup": "popup.html",
     "default_title": "Copy Selection"
@@ -12,6 +13,11 @@
     {
       "matches": ["<all_urls>"],
       "js": ["content_script.js"]
+    },
+    {
+      "matches": ["https://www.google.com/travel/flights/*"],
+      "js": ["flight_copy.js"],
+      "run_at": "document_idle"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update manifest to register new Google Flights content script
- add content script that inserts a "Copy" button on each result row
- show confirmation toast on successful copy
- document the new feature in README

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68583129e924832ca8b5cb4537d88cbb